### PR TITLE
Show correct desired experience on PayPal pages

### DIFF
--- a/src/app/client/js/patterns/buynow.jsx
+++ b/src/app/client/js/patterns/buynow.jsx
@@ -36,7 +36,7 @@ export let buynow = {
                     branding: true, // optional
                     size:  'small', // small | medium | large | responsive
                     shape: 'rect',   // pill | rect
-                    color: 'gold'   // gold | blue | silve | black
+                    color: 'gold'   // gold | blue | silver | black
                 },
 
                 // PayPal Client IDs - replace with your own
@@ -46,6 +46,9 @@ export let buynow = {
                     sandbox:    'AZDxjDScFpQtjWTOUtWKbyN_bDt4OgqaF4eYXlewfBP4-8aqX3PiV8e1GWU6liB2CUXlkA59kJXE7M6R',
                     production: '<insert production client id>'
                 },
+
+                // Show the buyer a 'Pay Now' button in the checkout flow
+                commit: true,
 
                 // Wait for the PayPal button to be clicked
 

--- a/src/app/client/js/patterns/mark.jsx
+++ b/src/app/client/js/patterns/mark.jsx
@@ -83,6 +83,15 @@ export let mark = {
                     production: '<insert production client id>'
                 },
 
+                style: {
+                    label: 'pay',
+                    size:  'small',
+                    shape: 'pill',
+                    color: 'gold'
+                },
+
+                commit: true,
+
                 payment: function(data, actions) {
                     return actions.payment.create({
                         payment: {

--- a/src/app/client/js/patterns/pay.jsx
+++ b/src/app/client/js/patterns/pay.jsx
@@ -45,6 +45,9 @@ export let pay = {
                     production: '<insert production client id>'
                 },
 
+                // Show the buyer a 'Pay Now' button in the checkout flow
+                commit: true,
+                
                 // Wait for the PayPal button to be clicked
 
                 payment: function(data, actions) {


### PR DESCRIPTION
Adding `commit: true` to examples that would not require further user action.

This will make it easier for developers to visualise the recommended experience.