### PR TITLE
monkey patch for fetch API to always populate the `x-csrf-token` header

### DIFF
--- a/src/app/client/js/index.jsx
+++ b/src/app/client/js/index.jsx
@@ -4,6 +4,17 @@ import { App } from './components/app';
 import { render } from 'react-dom';
 import { Router, Route, hashHistory, IndexRedirect } from 'react-router';
 
+const fetchMonkeyPatch = window.fetch;
+function newFetch (url, options, ...args) {
+    options = options || {};
+    options.headers = options.headers || {};
+    options.headers['x-csrf-token'] = document.body.getAttribute('data-csrf');
+
+    return fetchMonkeyPatch(url, options, ...args);
+}
+
+window.fetch = newFetch;
+
 render((
   <Router history={hashHistory}>
     <Route path="/" component={App}/>

--- a/src/app/server/server.js
+++ b/src/app/server/server.js
@@ -27,4 +27,4 @@ module.exports = function(options) {
     routes(app);
 
     return app;
-}
+};


### PR DESCRIPTION
Developer docs demo app fails when using the pattern integration
https://developer.paypal.com/demo/checkout/#/pattern/server

This is because the `x-csrf-token` header is not populated for every serverside request. 
We're monkeypatching fetch api so it will always populate it for every request to our backend. 