### PR TITLE
Replace legacy react hooks

### DIFF
--- a/src/app/build/demo.js
+++ b/src/app/build/demo.js
@@ -3478,7 +3478,7 @@ var App = exports.App = function (_React$Component) {
         this.setState({ code: code, errors: [] });
     };
 
-    App.prototype.componentWillMount = function componentWillMount() {
+    App.prototype.componentDidMount = function componentDidMount() {
         if (window.location.hash === '#/') {
             window.location.hash = '#/pattern/client';
         }
@@ -18943,9 +18943,8 @@ var Editor = exports.Editor = function (_React$Component) {
         this.setState({ editor: editor });
     };
 
-    Editor.prototype.componentWillUpdate = function componentWillUpdate(nextProps, nextState) {
-        nextState.editor.setValue((0, _lib.stripIndent)(nextProps.code), -1);
-        this.props.onChange(nextProps.code);
+    Editor.prototype.componentDidUpdate = function componentDidUpdate() {
+        this.state.editor.setValue((0, _lib.stripIndent)(this.props.code), -1);
     };
 
     return Editor;

--- a/src/app/client/js/components/app.jsx
+++ b/src/app/client/js/components/app.jsx
@@ -38,7 +38,7 @@ export class App extends React.Component {
         this.setState({ code, errors: [] });
     }
 
-    componentWillMount() {
+    componentDidMount() {
         if (window.location.hash === '#/') {
             window.location.hash = '#/pattern/client';
         }

--- a/src/app/client/js/components/editor.jsx
+++ b/src/app/client/js/components/editor.jsx
@@ -43,8 +43,7 @@ export class Editor extends React.Component {
         this.setState({ editor: editor });
     }
 
-    componentWillUpdate(nextProps, nextState){
-        nextState.editor.setValue(stripIndent(nextProps.code), -1);
-        this.props.onChange(nextProps.code);
+    componentDidUpdate() {
+        this.state.editor.setValue(stripIndent(this.props.code), -1);
     }
 }


### PR DESCRIPTION
This PR replaces the legacy `componentWillMount` and `componentWillUpdate` react hooks. Previously these warnings were showing in dev tools:

<img width="1792" alt="componentWillMount warnings" src="https://user-images.githubusercontent.com/534034/85596206-246b5500-b60f-11ea-9fef-ef342194bb7f.png">

This PR fixes these warnings and will make it easier to update react.