### PR TITLE
Update strategy for managing sandbox credentials

### DIFF
--- a/src/app/server/server.js
+++ b/src/app/server/server.js
@@ -3,6 +3,7 @@ const path = require('path');
 const cookieParser = require('cookie-parser');
 const bodyParser = require('body-parser');
 
+const config = require('./config');
 const routes = require('./routes');
 
 module.exports = function (options) {
@@ -26,7 +27,12 @@ module.exports = function (options) {
   app.use(
     function setup(req, res, next) {
       req.v4app = this;
-      req.sandboxCredentials = options.sandboxCredentials || {};
+      req.sandboxCredentials = req.sandboxCredentials || {};
+
+      if (!req.sandboxCredentials.clientID) {
+        req.sandboxCredentials.clientID = config.client.sandbox;
+      }
+
       next();
     }.bind(this)
   );


### PR DESCRIPTION
This PR updates the strategy for passing in the `sandboxCredentials` from the parent app. 
- This paypal-checkout-demo app is responsible for setting the clientID. 
- The parent express app is responsible for securely passing in the secret at runtime via middleware using `req.sandboxCredentials`. 